### PR TITLE
Request in bulk closes #2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,59 @@
-# Created by .ignore support plugin (hsz.mobi)
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
 
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
 build/
+develop-eggs/
 dist/
-
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
 *.egg-info/
+.installed.cfg
 *.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,91 @@
+.PHONY: clean clean-test clean-pyc clean-build docs help bump
+.DEFAULT_GOAL := help
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+try:
+	from urllib import pathname2url
+except:
+	from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
+
+help:
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
+clean: clean-build clean-pyc clean-test ## remove all build, test, coverage and Python artifacts
+
+
+clean-build: ## remove build artifacts
+	rm -fr build/
+	rm -fr dist/
+	rm -fr .eggs/
+	find . -name '*.egg-info' -exec rm -fr {} +
+	find . -name '*.egg' -exec rm -f {} +
+
+clean-pyc: ## remove Python file artifacts
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+clean-test: ## remove test and coverage artifacts
+	rm -fr .tox/
+	rm -f .coverage
+	rm -fr htmlcov/
+
+lint: ## check style with flake8
+	flake8 robozilla tests
+
+test: ## run tests quickly with the default Python
+	py.test -v --boxed
+
+
+test-all: ## run tests on every Python version with tox
+	tox
+
+coverage: ## check code coverage quickly with the default Python
+	coverage run --source robozilla py.test
+
+		coverage report -m
+		coverage html
+		$(BROWSER) htmlcov/index.html
+
+docs: ## generate Sphinx HTML documentation, including API docs
+	rm -f docs/robozilla.rst
+	rm -f docs/modules.rst
+	sphinx-apidoc -o docs/ robozilla
+	$(MAKE) -C docs clean
+	$(MAKE) -C docs html
+	$(BROWSER) docs/_build/html/index.html
+
+servedocs: docs ## compile the docs watching for changes
+	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
+
+release: clean ## package and upload a release
+	python setup.py sdist upload
+	python setup.py bdist_wheel upload
+
+dist: clean ## builds source and wheel package
+	python setup.py sdist
+	python setup.py bdist_wheel
+	ls -l dist
+
+install: clean ## install the package to the active Python's site-packages
+	python setup.py install
+
+bump: test
+	bumpversion patch --config-file=setup.cfg

--- a/robozilla/bz.py
+++ b/robozilla/bz.py
@@ -12,25 +12,23 @@ from xml.parsers.expat import ExpatError, ErrorString
 from robozilla.constants import (
     BUGZILLA_ENVIRON_USER_NAME,
     BUGZILLA_ENVIRON_USER_PASSWORD_NAME,
-    BUGZILLA_URL
+    BUGZILLA_URL,
+    DEFAULT_INCLUDE_FIELDS
 )
 
 
 class BZReader(object):
 
-    include_fields = [
-        'id',
-        'status',
-        'whiteboard',
-        'resolution',
-        'flags',
-        'dupe_of',
-    ]
     _flags_fields = ('name', 'status')
     _flags_force_include = []
     _flags_key_filters = ['sat-*']
 
-    def __init__(self, credentials=None):
+    def __init__(self,
+                 credentials=None,
+                 include_fields=None,
+                 follow_duplicates=False,
+                 follow_clones=False):
+
         if credentials is None:
             credentials = {}
             if BUGZILLA_ENVIRON_USER_NAME in os.environ:
@@ -41,10 +39,13 @@ class BZReader(object):
                 credentials['password'] = os.environ[
                     BUGZILLA_ENVIRON_USER_PASSWORD_NAME]
 
-        self.credentials = credentials
-        self.credentials = {}
+        self.credentials = credentials or {}
         self._cache = {}
         self._connection = None
+
+        self.include_fields = include_fields or DEFAULT_INCLUDE_FIELDS
+        self.follow_duplicates = follow_duplicates
+        self.follow_clones = follow_clones
 
     def _get_connection(self):
         # bz_credentials to be defined, for the moment connect as anonymous
@@ -55,6 +56,8 @@ class BZReader(object):
         return self._connection
 
     def get_bug_data_in_bulk(self, bugs):
+        """Get bug_data in bulk by given chunk in bugs
+        bugs: a list of ids"""
         bz_conn = self._get_connection()
         include_fields = [
             field for field in self.include_fields
@@ -68,7 +71,7 @@ class BZReader(object):
         return chunk_data
 
     def get_bug_data(self, bug_id):
-        print "getting single BZ"
+        """Get data for a single bug_id"""
         bug_data = self._cache.get(bug_id)
         if not bug_data:
             bz_conn = self._get_connection()
@@ -86,7 +89,10 @@ class BZReader(object):
         return bug_data
 
     def set_bug_data_fields(self, bug):
-        print "Formatting bz", bug.id
+        """Get a bug object and returns a dict
+        containing included_fields and flags and also
+        add extra fields getting relations as dupes or
+        clones"""
         bug_data = {}
         for field in self.include_fields:
             if field == 'flags' and self._flags_fields:
@@ -117,11 +123,17 @@ class BZReader(object):
         else:
             bug_data['status_resolution'] = bug.status
 
-        if bug_data['dupe_of']:
-            bug_data['duplicate_of'] = self.get_bug_data(
-                bug_data['dupe_of'])
-        else:
-            bug_data['duplicate_of'] = None
+        # getting dupes are expensive and makes the elapsed time to be
+        # 20x slow  so it is by default disabled
+        if 'dupe_of' in self.include_fields and self.follow_duplicates:
+            if bug_data['dupe_of']:
+                bug_data['duplicate_of'] = self.get_bug_data(
+                    bug_data['dupe_of'])
+            else:
+                bug_data['duplicate_of'] = None
+
+        if self.follow_clones:
+            pass  # TODO: Implement this!!!
 
         bug_data['id'] = str(bug.id)
         self._cache[bug_data['id']] = bug_data

--- a/robozilla/constants.py
+++ b/robozilla/constants.py
@@ -4,3 +4,14 @@ BUGZILLA_ENVIRON_USER_PASSWORD_NAME = 'BUGZILLA_USER_PASSWORD'
 BUGZILLA_URL = "https://bugzilla.redhat.com/xmlrpc.cgi"
 
 FILE_NAME_PATTERN = '*.py'
+
+DEFAULT_INCLUDE_FIELDS = [
+    'id',
+    'status',
+    'whiteboard',
+    'resolution',
+    'flags',
+    # getting dupe_of field makes request very slow
+    # add this field explicitly and also follow_duplicates=True
+    # 'dupe_of',
+]

--- a/robozilla/parser.py
+++ b/robozilla/parser.py
@@ -15,16 +15,19 @@ def chunks(l, n):
 class Parser(object):
 
     def __init__(self, files_provider, filters=None, reporter=None,
-                 bz_reader=None, environment=None):
+                 bz_reader=None, environment=None, reader_options=None):
 
         if isinstance(files_provider, six.string_types):
                 files_provider = FilesProvider(files_provider)
 
         self.files_provider = files_provider
-        self.filters = filters if filters else [BZDecorator, BZIsOpen]
-        self.bz_reader = bz_reader if bz_reader else BZReader()
-        self.reporter = reporter if reporter else (
-            RawReporter(bz_reader=bz_reader, environment=environment))
+        self.filters = filters if filters is not None else [
+            BZDecorator, BZIsOpen
+        ]
+        self.bz_reader = bz_reader or BZReader(**(reader_options or {}))
+        self.reporter = reporter or RawReporter(
+            bz_reader=bz_reader, environment=environment
+        )
 
     def _parse_file(self, file_path):
         with open(file_path) as fr:
@@ -41,6 +44,7 @@ class Parser(object):
     def parse(self, report=False, bulk=True, chunk_size=150):
         if report:
             self.reporter.start()
+
         bug_objects = {}
         for file_path in self.files_provider.get_files():
             for data in self._parse_file(file_path):
@@ -72,7 +76,6 @@ class Parser(object):
             self.reporter.stop()
 
         return bug_objects
-
 
     def get_bugs_status(self):
         self.parse(report=False)

--- a/robozilla/parser.py
+++ b/robozilla/parser.py
@@ -6,6 +6,12 @@ from robozilla.providers.fs import FilesProvider
 from robozilla.reporters import RawReporter
 
 
+def chunks(l, n):
+    """Yield successive n-sized chunks from l."""
+    for i in range(0, len(l), n):
+        yield l[i:i + n]
+
+
 class Parser(object):
 
     def __init__(self, files_provider, filters=None, reporter=None,
@@ -32,16 +38,41 @@ class Parser(object):
 
                 line_number += 1
 
-    def parse(self, report=True):
-        self.reporter.start()
+    def parse(self, report=False, bulk=True, chunk_size=150):
+        if report:
+            self.reporter.start()
+        bug_objects = {}
         for file_path in self.files_provider.get_files():
             for data in self._parse_file(file_path):
                 bug_id, bug_file_path, line_number, handler_name = data
-                bug_data = self.bz_reader.get_bug_data(bug_id)
-                if report:
-                    self.reporter.write(bug_id, bug_data, handler_name,
-                                        bug_file_path, line_number)
-        self.reporter.stop()
+                bug_objects[bug_id] = {
+                    'bug_id': bug_id,
+                    'bug_file_path': bug_file_path,
+                    'line_number': line_number,
+                    'handler_name': handler_name
+                }
+
+        if bulk:
+            for chunk_ids in chunks(list(bug_objects.keys()), chunk_size):
+                chunk_data = self.bz_reader.get_bug_data_in_bulk(chunk_ids)
+                for bug_id, bug_data in chunk_data.items():
+                    bug_objects[bug_id]['bug_data'] = bug_data
+
+        if report:
+            self.reporter.output('{} bugs found'.format(len(bug_objects)))
+            self.reporter.write_header()
+            for bug_id, data in bug_objects.items():
+                self.reporter.write(
+                    bug_id,
+                    data.get('bug_data', self.bz_reader.get_bug_data(bug_id)),
+                    data['handler_name'],
+                    data['bug_file_path'],
+                    data['line_number']
+                )
+            self.reporter.stop()
+
+        return bug_objects
+
 
     def get_bugs_status(self):
         self.parse(report=False)

--- a/robozilla/reporters/base.py
+++ b/robozilla/reporters/base.py
@@ -78,7 +78,7 @@ class RawReporter(object):
             file_path
         ))
 
-        duplicate_of_data = bug_data['duplicate_of']
+        duplicate_of_data = bug_data.get('duplicate_of')
         ind = 4
         while duplicate_of_data is not None:
             tab_str = ' '*ind
@@ -92,6 +92,16 @@ class RawReporter(object):
             )
             duplicate_of_data = duplicate_of_data['duplicate_of']
             ind *= 2
+
+    def write_header(self):
+        self.output('{0} | {1} | {2} | {3} | {4} -> {5}'.format(
+            self._left_just_string('Handler', 17),
+            self._left_just_string('BZ', 10),
+            self._left_just_string('State', 22),
+            self._left_just_string('Flags', 22),
+            'Line',
+            'File'
+        ))
 
     def stop(self, success=True):
         self._started = False

--- a/robozilla/scan.py
+++ b/robozilla/scan.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 from robozilla.parser import Parser
+from robozilla.constants import DEFAULT_INCLUDE_FIELDS
 
 
 def main():
@@ -19,7 +20,11 @@ def main():
         filters=None,
         reporter=None,
         bz_reader=None,
-        environment=None
+        environment=None,
+        reader_options={
+            'follow_duplicates': True,
+            'include_fields': DEFAULT_INCLUDE_FIELDS + ['dupe_of']
+        }
     )
     parser.parse(report=True)
 

--- a/robozilla/scan.py
+++ b/robozilla/scan.py
@@ -21,7 +21,7 @@ def main():
         bz_reader=None,
         environment=None
     )
-    parser.parse()
+    parser.parse(report=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fix #2 

- Perform bulk requests by default (chunks of 150 BZ id per request)
- When used in command line, add `dupe-of` field and follow duplicates
- When using programatically, by default do not include `dupe_of` because it takes much time
- Added Makefile and gitignore 
- Added `write_reader` method